### PR TITLE
added a divider on user settings page

### DIFF
--- a/apolloschurchapp/src/user-settings/index.js
+++ b/apolloschurchapp/src/user-settings/index.js
@@ -86,6 +86,7 @@ const UserSettings = () => {
                     <CellIcon name="arrow-next" />
                   </Cell>
                 </Touchable>
+                <Divider />
                 <Touchable
                   onPress={() => {
                     navigation.navigate('Notifications');


### PR DESCRIPTION
There was a missing divider on the user settings page between Change Password and Notification Settings.