### PR TITLE
chore: bump version to 6.0.9

### DIFF
--- a/apolloschurchapp/android/app/build.gradle
+++ b/apolloschurchapp/android/app/build.gradle
@@ -156,7 +156,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 71
-        versionName "6.0.8"
+        versionName "6.0.9"
         ndk {
             abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }

--- a/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
+++ b/apolloschurchapp/ios/OneSignalNotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.8</string>
+	<string>6.0.9</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/apolloschurchapp/ios/RiverValley-tvOS/Info.plist
+++ b/apolloschurchapp/ios/RiverValley-tvOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.8</string>
+	<string>6.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/apolloschurchapp/ios/RiverValley-tvOSTests/Info.plist
+++ b/apolloschurchapp/ios/RiverValley-tvOSTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.8</string>
+	<string>6.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/apolloschurchapp/ios/RiverValley/Info.plist
+++ b/apolloschurchapp/ios/RiverValley/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.8</string>
+	<string>6.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apolloschurchapp/ios/RiverValleyTests/Info.plist
+++ b/apolloschurchapp/ios/RiverValleyTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.8</string>
+	<string>6.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "RiverValley",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "private": true,
   "engines": {
     "node": ">=12.x.x"


### PR DESCRIPTION
This PR bumps version for working deploys.

# The Issue

<img width="711" alt="Screen Shot 2021-11-15 at 2 56 15 PM" src="https://user-images.githubusercontent.com/72768221/141852632-8b5e09fc-befc-410e-b190-6a4655d49770.png">


