### PR TITLE
Add additional OneSignal tagging

### DIFF
--- a/apolloschurchapp/src/content-single/ContentSingle.js
+++ b/apolloschurchapp/src/content-single/ContentSingle.js
@@ -25,6 +25,13 @@ const ContentSingle = (props) => {
           ... on ContentNode {
             title
           }
+          # for advanced onesignal notifications and analytics
+          ... on ContentItem {
+            parentChannel {
+              name
+              id
+            }
+          }
         }
       }
     `,
@@ -43,6 +50,7 @@ const ContentSingle = (props) => {
         properties={{
           title: data?.node?.title,
           itemId: nodeId,
+          parentChannel: data?.node?.parentChannel?.name,
         }}
       />
       <PaddedNodeSingleConnected nodeId={nodeId} />


### PR DESCRIPTION
Josee wants to experiment with sending some more targeted/advanced push notifications. This sets up some initial tagging in One Signal so that they can do that.

If you want to see what tags get set, feel free to `console.log(tags)` right before the `OneSignal.sendTags()` call. 

If this works out well for RV, we'll likely look to adding this to core.