### PR TITLE
chore: updated ui-kit for new notification dots

### DIFF
--- a/apolloschurchapp/ios/Podfile.lock
+++ b/apolloschurchapp/ios/Podfile.lock
@@ -628,7 +628,7 @@ SPEC CHECKSUMS:
   BugsnagReactNative: a96bc039e0e4ec317a8b331714393d836ca60557
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
@@ -639,7 +639,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OneSignal: e4dfb1912410f302dc9661ce98fc829f6c18ff6a
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b

--- a/apolloschurchapp/ios/Podfile.lock
+++ b/apolloschurchapp/ios/Podfile.lock
@@ -628,7 +628,7 @@ SPEC CHECKSUMS:
   BugsnagReactNative: a96bc039e0e4ec317a8b331714393d836ca60557
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
@@ -639,7 +639,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: 8a20b5c5fcf9436cac58551dc049867247f64b00
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OneSignal: e4dfb1912410f302dc9661ce98fc829f6c18ff6a
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b

--- a/apolloschurchapp/package.json
+++ b/apolloschurchapp/package.json
@@ -54,7 +54,7 @@
     "@apollosproject/ui-connected": "^2.29.3",
     "@apollosproject/ui-fragments": "^2.29.3",
     "@apollosproject/ui-htmlview": "^2.29.3",
-    "@apollosproject/ui-kit": "^2.38.1-canary.7",
+    "@apollosproject/ui-kit": "^2.41.1-canary.7",
     "@apollosproject/ui-mapview": "^2.31.1-canary.0",
     "@apollosproject/ui-media-player": "^2.30.1-canary.4",
     "@apollosproject/ui-notifications": "^2.33.1-canary.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,10 +375,10 @@
     entities "^1.1.2"
     htmlparser2 "3.9.2"
 
-"@apollosproject/ui-kit@^2.38.1-canary.7":
-  version "2.38.1-canary.7"
-  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-2.38.1-canary.7.tgz#d01bf904c01a4c37a3315f024786b8266174557c"
-  integrity sha512-xflY9+gTsBR2G1++EeKl+fHw2VdbvNpGzcH1Oh3HwXdp9/dm0jy22smKg3Gp2xZI5xFEvh5VrzK0atQa1Lq44A==
+"@apollosproject/ui-kit@^2.41.1-canary.7":
+  version "2.41.1-canary.7"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-2.41.1-canary.7.tgz#fc2dcfd33b582081b15a5b8ecce632f9c7a4ef89"
+  integrity sha512-JrUDqaZmbK1y7RVg79nIVL4+FXtq3IfG7v3eAFC9agqnx8QHcbQMzipicJNnzZF0KQAIAnBWeQqYJkG/pmt2AA==
   dependencies:
     "@react-native-community/blur" "^3.6.0"
     "@react-native-picker/picker" "^1.9.4"
@@ -386,6 +386,7 @@
     lodash "^4.17.11"
     moment "^2.24.0"
     numeral "^2.0.6"
+    phosphor-react-native "^0.4.0"
     react-native-keyboard-avoiding-scroll-view "1.0.1"
     react-native-modal-datetime-picker "^9.0.0"
     react-native-tab-view "1.0.2"
@@ -13166,6 +13167,11 @@ pgpass@1.x:
   integrity sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==
   dependencies:
     split2 "^3.1.1"
+
+phosphor-react-native@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/phosphor-react-native/-/phosphor-react-native-0.4.0.tgz#b843bd39a8970a53fd5b7729baa39fa3a9c0bf1b"
+  integrity sha512-FsNbV9agH+AZCqEvlAAguK1giRSgEOWIYjjtwrhQj+mcUbZz5WuZgMw9KPjumY4W0f16qkrq1ohsnCX2tu24Qg==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"


### PR DESCRIPTION
Adds the ui-kit canary. @redreceipt Just tagging you on this because when I ran `yarn` the podfile changed unexpectedly, which I know has caused issues in past PRs. Any concern there?

<img src="https://user-images.githubusercontent.com/72768221/147786655-fcc6b549-66ad-4a50-b296-4dcf1fd91369.png" width="40%">