### PR TITLE
chore: added mavenCentral and moved jcenter to bottom

### DIFF
--- a/apolloschurchapp/android/build.gradle
+++ b/apolloschurchapp/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.3")
@@ -23,9 +23,10 @@ buildscript {
 
 allprojects {
     repositories {
+        // bug in react-native-video, needs jcenter
+        // https://github.com/react-native-video/react-native-video/issues/2468
+        mavenCentral()
         mavenLocal()
-        google()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -34,6 +35,13 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-        maven { url "https://jitpack.io" }
+
+        google()
+        maven { url 'https://www.jitpack.io' }
+        jcenter() {
+            content {
+                includeModule("com.yqritc", "android-scalablevideoview")
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR tries to fix failing Android deploys. This builds locally with no errors.

<img width="1120" alt="Screen Shot 2022-01-07 at 9 11 40 AM (1)" src="https://user-images.githubusercontent.com/72768221/148600852-7a9ca2de-3a63-44a7-88c2-a9315e55d792.png">