### PR TITLE
chore: filter future children items

### DIFF
--- a/apollos-church-api/src/data/ContentItem.js
+++ b/apollos-church-api/src/data/ContentItem.js
@@ -18,6 +18,21 @@ class dataSource extends ContentItem.dataSource {
 
     return features;
   };
+
+  getChildren = async (model) => {
+    const children = await super.getChildren(model);
+
+    const filteredChildren = children.filter(
+      (child) =>
+        child.active &&
+        (child.publishAt === null || child.publishAt < new Date()) &&
+        (child.expireAt === null || child.expireAt > new Date())
+    );
+
+    if (filteredChildren.length === 0) return [];
+
+    return filteredChildren;
+  };
 }
 
 const resolver = {


### PR DESCRIPTION
## About

This PR filters out children items that are in the future. We are doing this in Core, but since they are a legacy app, they didn't get this bug fix.

## Screenshots

|Before|After|
|---|---|
|![IMG_0068](https://user-images.githubusercontent.com/72768221/207400209-a1da4976-d97e-402e-a702-bd0d81100265.PNG)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 11 13 31](https://user-images.githubusercontent.com/72768221/207400223-cb8652fc-51e5-4379-b82f-dcb3004f76dc.png)|
|![IMG_0065](https://user-images.githubusercontent.com/72768221/207400182-af2da6a4-2db8-4dc4-9f64-7402f224d20b.PNG)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 11 12 26](https://user-images.githubusercontent.com/72768221/207400200-782a03d2-ee96-4c15-be82-16b56666300c.png)|
|![IMG_0066](https://user-images.githubusercontent.com/72768221/207400203-e30fa69e-aa87-4754-a107-030ef6f032e5.PNG)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 11 12 42](https://user-images.githubusercontent.com/72768221/207400206-e4067406-91eb-41bd-9e6c-060672a17901.png)|
|![IMG_0067](https://user-images.githubusercontent.com/72768221/207400215-d766802e-f4b3-4d3c-8ebc-311125469f69.PNG)|![Simulator Screen Shot - iPhone 14 Pro - 2022-12-13 at 11 13 49](https://user-images.githubusercontent.com/72768221/207400227-7bd1de47-0bc8-4866-81c2-5ec2e6c11d69.png)|
