### PR TITLE
Update go tab links

### DIFF
--- a/apolloschurchapp/src/tabs/connect/ActionBar.js
+++ b/apolloschurchapp/src/tabs/connect/ActionBar.js
@@ -6,16 +6,14 @@ const Toolbar = () => (
     {(openUrl) => (
       <ActionBar>
         <ActionBarItem
-          onPress={() => openUrl('https://www.rivervalley.org/smallgroups/')}
+          onPress={() => openUrl('https://rivervalley.org/all-small-groups/')}
           icon="groups"
           label="Groups"
         />
         <ActionBarItem
-          onPress={() =>
-            openUrl('https://www.rivervalley.org/next-steps/serve/')
-          }
-          icon="like"
-          label="Serve"
+          onPress={() => openUrl('https://rock.rivervalley.org/myaccount')}
+          icon="user"
+          label="My Account"
         />
         <ActionBarItem
           onPress={() =>

--- a/apolloschurchapp/src/tabs/connect/ActionTable/index.js
+++ b/apolloschurchapp/src/tabs/connect/ActionTable/index.js
@@ -73,6 +73,26 @@ const ActionTable = () => (
               <CellIcon name="arrow-next" />
             </Cell>
           </Touchable>
+          <Divider />
+          <Touchable
+            onPress={() => openUrl('https://rivervalley.org/serve-teams/')}
+          >
+            <Cell>
+              <CellText>Join a Serve Team:</CellText>
+              <CellIcon name="arrow-next" />
+            </Cell>
+          </Touchable>
+          <Divider />
+          <Touchable
+            onPress={() =>
+              openUrl('https://myrock.rivervalley.org/ScheduleToolbox')
+            }
+          >
+            <Cell>
+              <CellText>View Serve Team schedule</CellText>
+              <CellIcon name="arrow-next" />
+            </Cell>
+          </Touchable>
         </TableView>
       </View>
     )}

--- a/apolloschurchapp/src/tabs/connect/ActionTable/index.js
+++ b/apolloschurchapp/src/tabs/connect/ActionTable/index.js
@@ -78,7 +78,7 @@ const ActionTable = () => (
             onPress={() => openUrl('https://rivervalley.org/serve-teams/')}
           >
             <Cell>
-              <CellText>Join a Serve Team:</CellText>
+              <CellText>Join a Serve Team</CellText>
               <CellIcon name="arrow-next" />
             </Cell>
           </Touchable>


### PR DESCRIPTION
Updates links in mobile app on the Go tab. 
- Groups link updated.
- Serve link changed to 'My Account'
- Added "Join a Serve Team"
- Added "View Serve Team schedule"

<img width="422" alt="image" src="https://user-images.githubusercontent.com/2528817/220202239-940a8a80-5001-4050-8d77-012fd1d50890.png">
<img width="416" alt="image" src="https://user-images.githubusercontent.com/2528817/220202555-48accd88-86ef-49c4-85b2-4f7747211107.png">


HubSpot Ticket:
https://app.hubspot.com/contacts/8332066/ticket/1444039981/

Basecamp Ticket:
https://3.basecamp.com/3926363/buckets/27088370/card_tables/cards/5858070708#__recording_5858605060