### PR TITLE
chore: Boost Position of Daily Scripture

### DIFF
--- a/apollos-church-api/config.postgres.yml
+++ b/apollos-church-api/config.postgres.yml
@@ -101,14 +101,6 @@ TABS:
             channelIds:
               - 6b05a1f6-13d9-439c-a963-6f5bba4f55f4
             limit: 1
-    - subtitle: YTH Devotional
-      type: VerticalCardList
-      algorithms:
-        - type: CONTENT_FEED
-          arguments:
-            channelIds:
-              - fc5e2398-4224-4ed6-b3dd-a13e4748b35a
-            limit: 1
     - subtitle: Daily Scripture
       algorithms:
         - type: CONTENT_FEED
@@ -117,6 +109,14 @@ TABS:
             channelIds:
               - 299478a2-2bb9-4a8c-8158-49aa6399d28f
       type: VerticalCardList
+    - subtitle: YTH Devotional
+      type: VerticalCardList
+      algorithms:
+        - type: CONTENT_FEED
+          arguments:
+            channelIds:
+              - fc5e2398-4224-4ed6-b3dd-a13e4748b35a
+            limit: 1
     - subtitle: Easter at River Valley
       algorithms:
         - type: CONTENT_FEED


### PR DESCRIPTION
Per a followup to a previous support ticket, the following was requested

> One more thing- would the YTH devotional be able to appear underneath Daily SOAP? (Want to keep SOAP at the top!)

This PR switches the order of the **YTH Devotional** to place it _below_ the **Daily Scripture**